### PR TITLE
15 cant create a route that uses plugins and plugin config id attributest simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## x.x.x (Unreleased)
 
+## 1.2.1 (22 Mar, 2024)
+
+BUG FIXES:
+
+- resource/apisix_route: Can't create a route that uses `plugins` and `plugin_config_id` attributest simultaneously ([#15](https://github.com/rework-space-com/terraform-provider-apisix/issues/15))
+
 ## 1.2.0 (29 Feb, 2024)
 
 BREAKING CHANGES:

--- a/apisix/route_resource.go
+++ b/apisix/route_resource.go
@@ -59,7 +59,6 @@ func (r *routeResource) ConfigValidators(ctx context.Context) []resource.ConfigV
 			path.MatchRoot("remote_addrs"),
 		),
 		resourcevalidator.Conflicting(
-			path.MatchRoot("plugins"),
 			path.MatchRoot("plugin_config_id"),
 			path.MatchRoot("script"),
 		),


### PR DESCRIPTION
Resolves https://github.com/rework-space-com/terraform-provider-apisix/issues/15