### PR TITLE
feat: add support for `PURGE` http method

### DIFF
--- a/apisix/model/structs.go
+++ b/apisix/model/structs.go
@@ -15,4 +15,5 @@ var HttpMethods = []string{
 	"UNLOCK",
 	"PATCH",
 	"TRACE",
+	"PURGE",
 }


### PR DESCRIPTION
Hi,

The `PURGE` http method is required to invalidate the apisix `proxy-cache`. Would be great to have this supported. 

Thanks